### PR TITLE
Fix: Ensure enrollment feedback messages are displayed

### DIFF
--- a/WebTech_SkillStream_Frontend/src/pages/Details.js
+++ b/WebTech_SkillStream_Frontend/src/pages/Details.js
@@ -29,8 +29,8 @@ export const Details = () => {
   useEffect(() => {
     if (message || error) {
       setTimeout(() => {
-        dispatch(apis.resetAll());
-        window.location.href = "/courses";
+        // dispatch(apis.resetAll()); // Removed for now
+        // window.location.href = "/courses"; // Removed for now
       }, 2000);
     }
   }, [message, error, dispatch]);


### PR DESCRIPTION
I modified `Details.js` to prevent automatic redirection after you attempt to enroll in a course. This ensures that success or error messages returned from the backend are visible to you on the course details page.

The backend `EnrollmentController.java` was already returning appropriate feedback; the issue was solely on the frontend where messages were cleared too quickly by a redirect.